### PR TITLE
Fix handling of empty body with description

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# 0.1.2 - 2015-09-21
+
+- Fix handling of request/responses with empty bodies but including a description. These must make use of an empty body via `+ Body` or the description is considered the body content.
+
 # 0.1.1 - 2015-09-15
 
 - Fix packaging issue that prevented the template from shipping with the published npm package.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-apib-serializer",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "API Blueprint serializer for Fury.js",
   "main": "./lib/adapter.js",
   "repository": {

--- a/template.nunjucks
+++ b/template.nunjucks
@@ -24,10 +24,10 @@ FORMAT: 1A
   {% if example.dataStructure %}
     {{ example.dataStructure.content|mson|indent(4) }}
   {% endif %}
-  {% if example.messageBody %}
+  {% if example.messageBody or example|getCopy %}
     + Body
 
-            {{ example.messageBody.content|pretty|indent(12) }}
+            {{ example.messageBody.content|default('', true)|pretty|indent(12) }}
 
   {% endif %}
   {% if example.messageBodySchema %}

--- a/test/fixtures/sample.apib
+++ b/test/fixtures/sample.apib
@@ -81,6 +81,12 @@ Restart a frob instance
 
 + Relation: restart
 
++ Response 204
+
+    There is no content.
+
+    + Body
+
 ## Data Structures
 
 ### User

--- a/test/fixtures/sample.json
+++ b/test/fixtures/sample.json
@@ -58,7 +58,9 @@
           ["copy", {}, {}, "Restart a frob instance"],
           ["httpTransaction", {}, {}, [
             ["httpRequest", {}, {"method": "POST"}, []],
-            ["httpResponse", {}, {}, []]
+            ["httpResponse", {}, {"statusCode": 204}, [
+              ["copy", {}, {}, "There is no content."]
+            ]]
           ]]
         ]]
       ]]


### PR DESCRIPTION
It is incorrect to have a snippet like this:

``` apib
+ Response 204

    This is a description.
```

The correct way to do this with API Blueprint is currently by using an empty body block:

``` apib
+ Response 204

    This is a description

    + Body
```

This updates the serializer to handle that case.
