### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.6.0
+
+## Enhancements
+
+- Compatibility with [Minim 0.20.1](https://github.com/refractproject/minim/releases/tag/v0.20.1)
+  and [Fury 3.0.0 Beta 6](https://github.com/apiaryio/fury.js/releases/tag/v3.0.0-beta.6).
+
 # 0.5.0 - 2017-08-09
 
 - Compatibility with [Minim 0.19](https://github.com/refractproject/minim/releases/tag/v0.19.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fury-adapter-apib-serializer",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "API Blueprint serializer for Fury.js",
   "main": "./lib/adapter.js",
   "repository": {
@@ -20,13 +20,13 @@
     "nunjucks": "^2.0.0"
   },
   "peerDependencies": {
-    "fury": "^3.0.0-beta.4"
+    "fury": "^3.0.0-beta.6"
   },
   "devDependencies": {
     "chai": "^3.2.0",
-    "fury": "^3.0.0-beta.4",
+    "fury": "^3.0.0-beta.6",
     "glob": "^7.1.1",
-    "peasant": "^1.1.0"
+    "peasant": "1.1.0"
   },
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
Compatibility with [Minim 0.20.1](https://github.com/refractproject/minim/releases/tag/v0.20.1) and [Fury 3.0.0 Beta 6](https://github.com/apiaryio/fury.js/releases/tag/v3.0.0-beta.6).