### PR TITLE
Remove transpilation with Peasant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
-/lib
 .vagrant
 npm-debug.log
 package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-- '4'
 - '6'
 - '8'
 - '10'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
 - '8'
 - '10'
 script:
-- npm run ci
+- npm test
 after_script:
 - npm install -g codeclimate-test-reporter
 - npm run cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ node_js:
 - '10'
 script:
 - npm test
-after_script:
-- npm install -g codeclimate-test-reporter
-- npm run cover
-- codeclimate-test-reporter < coverage/lcov.info
 notifications:
   email: false
   slack:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Fury API Blueprint Serializer
 
+## Master
+
+## Breaking
+
+- Node 4 is no longer supported. Please use Node 6 or higher.
+
 ## 0.7.0
 
 ### Enhancements

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -2,11 +2,11 @@
  * API Blueprint serializer for Fury.js
  */
 
-import nunjucks from 'nunjucks';
-import path from 'path';
-import { renderAttributes, renderDataStructure } from './mson';
+const nunjucks = require('nunjucks');
+const path = require('path');
+const { renderAttributes, renderDataStructure } = require('./mson');
 
-import { indent, bodyOnly, resourceShorthand, pretty, getCopy } from './filters';
+const { indent, bodyOnly, resourceShorthand, pretty, getCopy } = require('./filters');
 
 const env = nunjucks.configure(path.dirname(__dirname), {
   autoescape: false,
@@ -20,15 +20,15 @@ env.addFilter('resourceShorthand', resourceShorthand);
 env.addFilter('pretty', pretty);
 env.addFilter('getCopy', getCopy);
 
-export const name = 'api-blueprint-serializer';
-export const mediaTypes = [
+const name = 'api-blueprint-serializer';
+const mediaTypes = [
   'text/vnd.apiblueprint',
 ];
 
 /*
  * Serialize an API into API Blueprint.
  */
-export function serialize({ api }, done) {
+function serialize({ api }, done) {
   nunjucks.render('template.nunjucks', { api }, (err, apib) => {
     if (err) {
       return done(err);
@@ -39,4 +39,4 @@ export function serialize({ api }, done) {
   });
 }
 
-export default { name, mediaTypes, serialize };
+module.exports = { name, mediaTypes, serialize };

--- a/lib/filters.js
+++ b/lib/filters.js
@@ -6,7 +6,7 @@
   * Indent a piece of multiline text by a number of spaces.
   * Setting `first` to `true` will also indent the first line.
   */
- export function indent(input, spaces, options = { first: false }) {
+ function indent(input, spaces, options = { first: false }) {
    let pre = '';
    let lines = [];
 
@@ -33,7 +33,7 @@
   * optionally has a content-type and nothing else. This lets us know when to
   * use a shorthand syntax in the template.
   */
- export function bodyOnly(payload) {
+ function bodyOnly(payload) {
    let headers;
 
    // First, we need to filter out the content-type header. This is handled
@@ -52,7 +52,7 @@
   * Detect when it is okay to use a resource shorthand, i.e. skip the resource
   * header and just do a single action with a URI.
   */
- export function resourceShorthand(resource) {
+ function resourceShorthand(resource) {
    return (!resource.title && !resource.description &&
            resource.transitions.length === 1 &&
            resource.transitions.get(0).computedHref);
@@ -65,7 +65,7 @@
   * - JSON
   *
   */
- export function pretty(input) {
+ function pretty(input) {
    let prettified;
 
    try {
@@ -81,6 +81,14 @@
   * Return all child elements with the element type of `copy` in a plain
   * old js array.
   */
- export function getCopy(element) {
+ function getCopy(element) {
    return element.children.filter(item => item.element === 'copy').elements;
  }
+
+module.exports = {
+  indent,
+  bodyOnly,
+  resourceShorthand,
+  pretty,
+  getCopy,
+};

--- a/lib/mson.js
+++ b/lib/mson.js
@@ -2,7 +2,7 @@
  * Renders refract elements into MSON.
  */
 
-import { indent } from './filters';
+const { indent } = require('./filters');
 
 /*
  * Get type information for an element, such as the element name, whether
@@ -205,7 +205,7 @@ function handle(name, element, { parent = null, spaces = 4, marker = '+',
 /*
  * Render out a piece of MSON from refract element instances.
  */
-export function renderDataStructure(dataStructure) {
+function renderDataStructure(dataStructure) {
   let mson = dataStructure.content;
 
   if (Array.isArray(mson)) {
@@ -220,7 +220,7 @@ export function renderDataStructure(dataStructure) {
   });
 }
 
-export function renderAttributes(dataStructure) {
+function renderAttributes(dataStructure) {
   let mson = dataStructure.content;
 
   if (Array.isArray(mson)) {
@@ -233,4 +233,4 @@ export function renderAttributes(dataStructure) {
   });
 }
 
-export default { renderDataStructure, renderAttributes };
+module.exports = { renderDataStructure, renderAttributes };

--- a/package.json
+++ b/package.json
@@ -8,15 +8,11 @@
     "url": "https://github.com/apiaryio/fury-adapter-apib-serializer.git"
   },
   "scripts": {
-    "test": "peasant test",
-    "ci": "peasant -s lint test build",
-    "prepublish": "npm run ci",
-    "cover": "peasant cover",
-    "peasant": "peasant",
-    "lint": "peasant lint"
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "test": "mocha"
   },
   "dependencies": {
-    "babel-runtime": "^6.23.0",
     "nunjucks": "^2.0.0"
   },
   "peerDependencies": {
@@ -24,9 +20,10 @@
   },
   "devDependencies": {
     "chai": "^4.1.2",
+    "eslint": "^5.9.0",
     "fury": "3.0.0-beta.7",
     "glob": "^7.1.2",
-    "peasant": "1.1.0"
+    "mocha": "^5.0.2"
   },
   "engines": {
     "node": ">=4"

--- a/test/adapter.js
+++ b/test/adapter.js
@@ -4,13 +4,13 @@
  * Tests for API Blueprint serializer.
  */
 
-import { expect } from 'chai';
-import fs from 'fs';
-import fury from 'fury';
-import glob from 'glob';
-import path from 'path';
-import { serialize } from '../src/adapter';
-import { indent } from '../src/filters';
+const { expect } = require('chai');
+const fs = require('fs');
+const fury = require('fury');
+const glob = require('glob');
+const path = require('path');
+const { serialize } = require('../lib/adapter');
+const { indent } = require('../lib/filters');
 
 const base = path.join(__dirname, 'fixtures');
 

--- a/test/mson.js
+++ b/test/mson.js
@@ -1,6 +1,6 @@
-import { expect } from 'chai';
-import { Fury } from 'fury';
-import { renderAttributes } from '../src/mson';
+const { expect } = require('chai');
+const { Fury } = require('fury');
+const { renderAttributes } = require('../lib/mson');
 
 const fury = new Fury();
 const elements = fury.minim.elements;


### PR DESCRIPTION
We're no longer using Peasant or transpilation in the Fury packages as we're targetting Node directly to simplify development.

This drops Node 4 support. This is the same process that has happened to all other Fury adapters.